### PR TITLE
Fixing sqlalchemy test failures

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -286,7 +286,7 @@ deps =
     mongoengine017: mongoengine>=0.17<0.18
     mongoengine018: mongoengine>=0.18<0.19
     mongoenginelatest: mongoengine>=0.18
-    mysqlconnector: mysql-connector-python
+    mysqlconnector: mysql-connector-python!=8.0.18
     mysqldb12: mysql-python>=1.2,<1.3
     mysqlclient13: mysqlclient>=1.3,<1.4
 # webob is required for Pylons < 1.0
@@ -443,7 +443,7 @@ basepython=python
 deps=
     cassandra-driver
     psycopg2
-    mysql-connector-python
+    mysql-connector-python!=8.0.18
     redis-py-cluster>=1.3.6,<1.4.0
     vertica-python>=0.6.0,<0.7.0
     kombu>=4.2.0,<4.3.0


### PR DESCRIPTION
Version 8.0.18 is causing segfaults in sqlalchemy tests.

Signed-off-by: Alex Boten <aboten@lightstep.com>