### PR TITLE
Remove py34 testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,47 +21,46 @@ envlist =
     flake8
     black
     wait
-    {py27,py34,py35,py36,py37,py38}-tracer{,-msgpackmin,-msgpack056,-msgpack060}
+    {py27,py35,py36,py37,py38}-tracer{,-msgpackmin,-msgpack056,-msgpack060}
     {py27,py35,py36,py37,py38}-profile{,-gevent}
     {py27,py35,py36,py37,py38}-profile-minreqs{,-gevent}
-    {py27,py34,py35,py36,py37,py38}-internal
-    {py27,py34,py35,py36,py37,py38}-integration{,-msgpackmin,-msgpack056,-msgpack060}
-    {py27,py34,py35,py36,py37,py38}-ddtracerun
-    {py27,py34,py35,py36,py37,py38}-test_utils
-    {py27,py34,py35,py36,py37,py38}-test_logging
+    {py27,py35,py36,py37,py38}-internal
+    {py27,py35,py36,py37,py38}-integration{,-msgpackmin,-msgpack056,-msgpack060}
+    {py27,py35,py36,py37,py38}-ddtracerun
+    {py27,py35,py36,py37,py38}-test_utils
+    {py27,py35,py36,py37,py38}-test_logging
 # Integrations environments
-    aiobotocore_contrib-py34-aiobotocore{02,03,04}
     aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010,011,latest}
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
     aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,latest}
     # Python 3.7 needs at least aiohttp 2.3
-    aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
-    aiohttp_contrib-{py34,py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10
+    aiohttp_contrib-{py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
+    aiohttp_contrib-{py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10
     aiohttp_contrib-{py35,py36,py37}-aiohttp{30,31,32,33,34,35,36}-aiohttp_jinja{015}-yarl10
     aiohttp_contrib-py38-aiohttp{30,31,32,33,36}-aiohttp_jinja015-yarl10
-    aiopg_contrib-{py34,py35,py36}-aiopg{012,015}
+    aiopg_contrib-{py35,py36}-aiopg{012,015}
     aiopg_contrib-py{37,38}-aiopg015
-    algoliasearch_contrib-{py27,py34,py35,py36,py37,py38}-algoliasearch{1,2}
-    asyncio_contrib-{py34,py35,py36,py37,py38}
+    algoliasearch_contrib-{py27,py35,py36,py37,py38}-algoliasearch{1,2}
+    asyncio_contrib-{py35,py36,py37,py38}
 # boto needs moto<1 and moto<1 does not support Python >= 3.7
-    boto_contrib-{py27,py34,py35,py36}-boto
-    botocore_contrib-{py27,py34,py35,py36,py37,py38}-botocore
-    bottle_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-bottle{11,12}-webtest
-    cassandra_contrib-{py27,py34,py35,py36,py37,py38}-cassandra{35,36,37,38,315}
+    boto_contrib-{py27,py35,py36}-boto
+    botocore_contrib-{py27,py35,py36,py37,py38}-botocore
+    bottle_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-bottle{11,12}-webtest
+    cassandra_contrib-{py27,py35,py36,py37,py38}-cassandra{35,36,37,38,315}
 # Non-4.x celery should be able to use the older redis lib, since it locks to an older kombu
-    celery_contrib-{py27,py34,py35,py36}-celery{31}-redis{210}
+    celery_contrib-{py27,py35,py36}-celery{31}-redis{210}
 # 4.x celery bumps kombu to 4.4+, which requires redis 3.2 or later, this tests against
 # older redis with an older kombu, and newer kombu/newer redis.
 # https://github.com/celery/kombu/blob/3e60e6503a77b9b1a987cf7954659929abac9bac/Changelog#L35
-    celery_contrib-{py27,py34,py35,py36}-celery{40,41}-{redis210-kombu43,redis320-kombu44}
+    celery_contrib-{py27,py35,py36}-celery{40,41}-{redis210-kombu43,redis320-kombu44}
 # Celery 4.2 is now limited to Kombu 4.3
 # https://github.com/celery/celery/commit/1571d414461f01ae55be63a03e2adaa94dbcb15d
-    celery_contrib-{py27,py34,py35,py36}-celery42-redis210-kombu43
+    celery_contrib-{py27,py35,py36}-celery42-redis210-kombu43
 # Celery 4.3 wants Kombu >= 4.4 and Redis >= 3.2
 # Python 3.7 needs Celery 4.3
-    celery_contrib-{py27,py34,py35,py36,py37,py38}-celery43-redis320-kombu44
-    consul_contrib-py{27,34,35,36,37,38}-consul{07,10,11}
-    dbapi_contrib-{py27,py34,py35,py36}
+    celery_contrib-{py27,py35,py36,py37,py38}-celery43-redis320-kombu44
+    consul_contrib-py{27,35,36,37,38}-consul{07,10,11}
+    dbapi_contrib-{py27,py35,py36}
 # Django  Python version support
 # 1.11  2.7, 3.4, 3.5, 3.6, 3.7 (added in 1.11.17)
 # 2.0   3.4, 3.5, 3.6, 3.7
@@ -70,56 +69,56 @@ envlist =
 # 3.0   3.6, 3.7, 3.8
 # 3.1   3.6, 3.7, 3.8
 # Source: https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
-    django_contrib{,_migration}-{py27,py34,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
+    django_contrib{,_migration}-{py27,py35,py36}-django{18,111}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     django_contrib{,_migration}-{py35}-django{20,21,22}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
     django_contrib{,_migration}-{py36,py37}-django{20,21,22,30,latest}-djangopylibmc06-djangoredis45-pylibmc-redis{210}-memcached
-    django_drf_contrib-{py27,py34,py35,py36}-django{111}-djangorestframework{34,37}
+    django_drf_contrib-{py27,py35,py36}-django{111}-djangorestframework{34,37}
     django_drf_contrib-{py35}-django{22}-djangorestframework{38,310,latest}
     django_drf_contrib-{py36,py37}-django{22}-djangorestframework{38,310,latest}
     django_drf_contrib-{py36,py37,py38}-django{30}-djangorestframework{310,latest}
     dogpile_contrib-{py27,py35,py36,py37,py38}-dogpilecache{06,07,08,latest}
-    elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
-    elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch1{100}
-    elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch2{50}
-    elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch5{50}
-    elasticsearch_contrib-{py27,py34,py35,py36}-elasticsearch6{40}
-    falcon_contrib{,_autopatch}-{py27,py34,py35,py36}-falcon{10,11,12,13,14}
-    flask_contrib{,_autopatch}-{py27,py34,py35,py36}-flask{010,011,012,10}-blinker
+    elasticsearch_contrib-{py27,py35,py36}-elasticsearch{16,17,18,23,24,51,52,53,54,63,64}
+    elasticsearch_contrib-{py27,py35,py36}-elasticsearch1{100}
+    elasticsearch_contrib-{py27,py35,py36}-elasticsearch2{50}
+    elasticsearch_contrib-{py27,py35,py36}-elasticsearch5{50}
+    elasticsearch_contrib-{py27,py35,py36}-elasticsearch6{40}
+    falcon_contrib{,_autopatch}-{py27,py35,py36}-falcon{10,11,12,13,14}
+    flask_contrib{,_autopatch}-{py27,py35,py36}-flask{010,011,012,10}-blinker
 # Flask <=0.9 does not support Python 3
     flask_contrib{,_autopatch}-{py27}-flask{09}-blinker
-    flask_cache_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
+    flask_cache_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-flask{010,011,012}-flaskcache{013}-memcached-redis{210}-blinker
     flask_cache_contrib{,_autopatch}-{py27}-flask{010,011}-flaskcache{012}-memcached-redis{210}-blinker
     futures_contrib-{py27}-futures{30,31,32}
-    futures_contrib-{py34,py35,py36,py37,py38}
-    gevent_contrib-{py27,py34,py35,py36}-gevent{11,12,13}
+    futures_contrib-{py35,py36,py37,py38}
+    gevent_contrib-{py27,py35,py36}-gevent{11,12,13}
     gevent_contrib-py{37,38}-gevent{13,14}
 # gevent 1.0 is not python 3 compatible
     gevent_contrib-{py27}-gevent{10}
-    grpc_contrib-{py27,py34,py35,py36,py37,py38}-grpc{112,113,114,115,116,117,118,119,120,121,122}
-    httplib_contrib-{py27,py34,py35,py36,py37,py38}
-    jinja2_contrib-{py27,py34,py35,py36,py37,py38}-jinja{27,28,29,210}
-    mako_contrib-{py27,py34,py35,py36,py37,py38}-mako{010,100}
+    grpc_contrib-{py27,py35,py36,py37,py38}-grpc{112,113,114,115,116,117,118,119,120,121,122}
+    httplib_contrib-{py27,py35,py36,py37,py38}
+    jinja2_contrib-{py27,py35,py36,py37,py38}-jinja{27,28,29,210}
+    mako_contrib-{py27,py35,py36,py37,py38}-mako{010,100}
     molten_contrib-py{36,37,38}-molten{070,072}
-    mongoengine_contrib-{py27,py34,py35,py36,py37,py38}-mongoengine{015,016,017,018,latest}-pymongo{latest}
-    mysql_contrib-{py27,py34,py35,py36,py37}-mysqlconnector
+    mongoengine_contrib-{py27,py35,py36,py37,py38}-mongoengine{015,016,017,018,latest}-pymongo{latest}
+    mysql_contrib-{py27,py35,py36,py37}-mysqlconnector
     mysqldb_contrib-{py27}-mysqldb{12}
-    mysqldb_contrib-{py27,py34,py35,py36,py37,py38}-mysqlclient{13}
-    psycopg_contrib-{py27,py34,py35,py36,37}-psycopg2{24,25,26,27,28}
+    mysqldb_contrib-{py27,py35,py36,py37,py38}-mysqlclient{13}
+    psycopg_contrib-{py27,py35,py36,37}-psycopg2{24,25,26,27,28}
 # psycopg <2.7 doesn't support Python 3.8: https://github.com/psycopg/psycopg2/issues/854
     psycopg_contrib-py{38}-psycopg2{28}
-    pylibmc_contrib-{py27,py34,py35,py36,py37,py38}-pylibmc{140,150}
+    pylibmc_contrib-{py27,py35,py36,py37,py38}-pylibmc{140,150}
     pylons_contrib-{py27}-pylons{096,097,010,10}
-    pymemcache_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-pymemcache{130,140}
-    pymongo_contrib-{py27,py34,py35,py36,py37}-pymongo{30,31,32,33,34,35,36,37,38,39,latest}-mongoengine{latest}
+    pymemcache_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-pymemcache{130,140}
+    pymongo_contrib-{py27,py35,py36,py37}-pymongo{30,31,32,33,34,35,36,37,38,39,latest}-mongoengine{latest}
 # pymongo does not yet support Python 3.8: https://github.com/pymssql/pymssql/issues/586
 # but these tests still work.
     pymongo_contrib-{py38}-pymongo{30,31,32,33,35,36,37,38,39,latest}-mongoengine{latest}
-    pymysql_contrib-{py27,py34,py35,py36,py37,py38}-pymysql{07,08,09}
-    pyramid_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-pyramid{17,18,19}-webtest
-    redis_contrib-{py27,py34,py35,py36,py37,py38}-redis{26,27,28,29,210,300}
-    rediscluster_contrib-{py27,py34,py35,py36,py37,py38}-rediscluster{135,136,200,latest}-redis210
-    requests_contrib{,_autopatch}-{py27,py34,py35,py36,py37,py38}-requests{208,209,210,211,212,213,219}
-    kombu_contrib-{py27,py34,py35,py36}-kombu{40,41,42}
+    pymysql_contrib-{py27,py35,py36,py37,py38}-pymysql{07,08,09}
+    pyramid_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-pyramid{17,18,19}-webtest
+    redis_contrib-{py27,py35,py36,py37,py38}-redis{26,27,28,29,210,300}
+    rediscluster_contrib-{py27,py35,py36,py37,py38}-rediscluster{135,136,200,latest}-redis210
+    requests_contrib{,_autopatch}-{py27,py35,py36,py37,py38}-requests{208,209,210,211,212,213,219}
+    kombu_contrib-{py27,py35,py36}-kombu{40,41,42}
     # Python 3.7 needs Kombu >= 4.2
     kombu_contrib-py{37,38}-kombu42
 # python 3.6 requests + gevent regression test
@@ -127,22 +126,22 @@ envlist =
 #      https://github.com/gevent/gevent/issues/903
     requests_gevent_contrib-{py36}-requests{208,209,210,211,212,213,219}-gevent{12,13}
     requests_gevent_contrib-py{37,38}-requests{208,209,210,211,212,213,219}-gevent13
-    sqlalchemy_contrib-{py27,py34,py35,py36,py37,py38}-sqlalchemy{10,11,12,13}-psycopg228-mysqlconnector
-    sqlite3_contrib-{py27,py34,py35,py36,py37,py38}-sqlite3
-    tornado_contrib-{py27,py34,py35,py36,py37,py38}-tornado{40,41,42,43,44,45}
+    sqlalchemy_contrib-{py27,py35,py36,py37,py38}-sqlalchemy{10,11,12,13}-psycopg228-mysqlconnector
+    sqlite3_contrib-{py27,py35,py36,py37,py38}-sqlite3
+    tornado_contrib-{py27,py35,py36,py37,py38}-tornado{40,41,42,43,44,45}
     tornado_contrib-py{37,38}-tornado{50,51,60}
     tornado_contrib-{py27}-tornado{40,41,42,43,44,45}-futures{30,31,32}
-    vertica_contrib-{py27,py34,py35,py36,py37,py38}-vertica{060,070}
+    vertica_contrib-{py27,py35,py36,py37,py38}-vertica{060,070}
 # Opentracer
-    {py27,py34,py35,py36,py37,py38}-opentracer
-    {py34,py35,py36,py37,py38}-opentracer_asyncio
-    {py34,py35,py36,py37,py38}-opentracer_tornado-tornado{40,41,42,43,44}
+    {py27,py35,py36,py37,py38}-opentracer
+    {py35,py36,py37,py38}-opentracer_asyncio
+    {py35,py36,py37,py38}-opentracer_tornado-tornado{40,41,42,43,44}
     {py27}-opentracer_gevent-gevent{10}
-    {py27,py34,py35,py36}-opentracer_gevent-gevent{11,12}
+    {py27,py35,py36}-opentracer_gevent-gevent{11,12}
     py{37,38}-opentracer_gevent-gevent{13,14}
 # Unit tests: pytest based test suite that do not require any additional dependency
-    unit_tests-{py27,py34,py35,py36,py37,py38}
-    benchmarks-{py27,py34,py35,py36,py37,py38}
+    unit_tests-{py27,py35,py36,py37,py38}
+    benchmarks-{py27,py35,py36,py37,py38}
 
 isolated_build = true
 
@@ -207,7 +206,6 @@ deps =
     aiobotocore03: aiobotocore>=0.3,<0.4
     aiobotocore02: aiobotocore>=0.2,<0.3
     aiobotocore02: multidict==4.5.2
-    aiobotocore{02,03,04}-{py34}: typing
     aiopg012: aiopg>=0.12,<0.13
     aiopg015: aiopg>=0.15,<0.16
     aiopg: sqlalchemy
@@ -233,8 +231,6 @@ deps =
     boto: boto
     boto: moto<1.0
     botocore: botocore
-    py34-botocore: PyYAML<5.3
-    py34-botocore: jsonpatch<1.25
     botocore: moto>=1.0,<2
     bottle11: bottle>=0.11,<0.12
     bottle12: bottle>=0.12,<0.13
@@ -451,8 +447,8 @@ commands =
 # integration tests
     integration: pytest {posargs} tests/test_integration.py
 # Contribs
-    aiobotocore_contrib-{py34,py35,py36,py37,py38}: pytest {posargs} tests/contrib/aiobotocore
-    aiopg_contrib-{py34,py35,py36,py37,py38}: pytest {posargs} tests/contrib/aiopg
+    aiobotocore_contrib-{py35,py36,py37,py38}: pytest {posargs} tests/contrib/aiobotocore
+    aiopg_contrib-{py35,py36,py37,py38}: pytest {posargs} tests/contrib/aiopg
     aiohttp_contrib: pytest {posargs} tests/contrib/aiohttp
     algoliasearch_contrib: pytest {posargs} tests/contrib/algoliasearch
     asyncio_contrib: pytest {posargs} tests/contrib/asyncio


### PR DESCRIPTION
Python 3.4 is deprecated, removing its testing environments.