### PR TITLE
fix: 128bit trace id propagation issue

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -5,11 +5,12 @@ from .internal.import_hooks import patch as patch_import_hooks
 
 patch_import_hooks()  # noqa: E402
 
-from .monkey import patch, patch_all
-from .pin import Pin
-from .span import Span
-from .tracer import Tracer
-from .settings import config
+from .monkey import patch, patch_all  # noqa: E402
+from .pin import Pin  # noqa: E402
+from .span import Span  # noqa: E402
+from .tracer import Tracer  # noqa: E402
+from .settings import config  # noqa: E402
+from .utils.deprecation import deprecated  # noqa: E402
 
 
 __version__ = "0.2.0"
@@ -38,6 +39,7 @@ def _excepthook(tp, value, traceback):
         return _ORIGINAL_EXCEPTHOOK(tp, value, traceback)
 
 
+@deprecated("This method will be removed altogether", "1.0.0")
 def install_excepthook():
     """Install a hook that intercepts unhandled exception and send metrics about them."""
     global _ORIGINAL_EXCEPTHOOK
@@ -45,6 +47,7 @@ def install_excepthook():
     sys.excepthook = _excepthook
 
 
+@deprecated("This method will be removed altogether", "1.0.0")
 def uninstall_excepthook():
     """Uninstall the global tracer except hook."""
     sys.excepthook = _ORIGINAL_EXCEPTHOOK

--- a/ddtrace/compat.py
+++ b/ddtrace/compat.py
@@ -184,7 +184,7 @@ except ImportError:
                 pass
             else:
                 if not (
-                    type(class_dict) is types.GetSetDescriptorType
+                    type(class_dict) is types.GetSetDescriptorType  # noqa: E721
                     and class_dict.__name__ == "__dict__"  # noqa: E721,E261,W504
                     and class_dict.__objclass__ is entry  # noqa: E261,W504
                 ):

--- a/ddtrace/opentracer/tracer.py
+++ b/ddtrace/opentracer/tracer.py
@@ -68,7 +68,7 @@ class Tracer(opentracing.Tracer):
             invalid_keys = config_invalid_keys(self._config)
             if invalid_keys:
                 str_invalid_keys = ','.join(invalid_keys)
-                raise ConfigException('invalid key(s) given (%s)'.format(str_invalid_keys))
+                raise ConfigException('invalid key(s) given ({})'.format(str_invalid_keys))
 
         if not self._service_name:
             raise ConfigException(""" Cannot detect the \'service_name\'.

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -283,8 +283,12 @@ class Span(object):
         return self.metrics.get(key)
 
     def to_dict(self):
+        trace_id = self.trace_id
+        # ensure 128 bit trace IDs are always trimmed
+        if self.trace_id.bit_length() > 63:
+            trace_id = int(format(self.trace_id, "016x")[-16:], 16)
         d = {
-            'trace_id': self.trace_id,
+            'trace_id': trace_id,
             'parent_id': self.parent_id,
             'span_id': self.span_id,
             'service': self.service,

--- a/ddtrace/span.py
+++ b/ddtrace/span.py
@@ -4,7 +4,12 @@ import sys
 import traceback
 
 from .compat import StringIO, stringify, iteritems, numeric_types, time_ns, is_integer
-from .constants import NUMERIC_TAGS, MANUAL_DROP_KEY, MANUAL_KEEP_KEY, SPAN_MEASURED_KEY
+from .constants import (
+    NUMERIC_TAGS,
+    MANUAL_DROP_KEY,
+    MANUAL_KEEP_KEY,
+    SPAN_MEASURED_KEY,
+)
 from .ext import SpanTypes, errors, priority, net, http
 from .internal.logger import get_logger
 
@@ -22,33 +27,32 @@ class Span(object):
 
     __slots__ = [
         # Public span attributes
-        'service',
-        'name',
-        'resource',
-        'span_id',
-        'trace_id',
-        'parent_id',
-        'meta',
-        'error',
-        'metrics',
-        'span_type',
-        'start_ns',
-        'duration_ns',
-        'tracer',
+        "service",
+        "name",
+        "resource",
+        "span_id",
+        "trace_id",
+        "parent_id",
+        "meta",
+        "error",
+        "metrics",
+        "span_type",
+        "start_ns",
+        "duration_ns",
+        "tracer",
         # Sampler attributes
-        'sampled',
+        "sampled",
         # Internal attributes
-        '_context',
-        'finished',
-        '_parent',
-        '__weakref__',
+        "_context",
+        "finished",
+        "_parent",
+        "__weakref__",
     ]
 
     def __init__(
         self,
         tracer,
         name,
-
         service=None,
         resource=None,
         span_type=None,
@@ -145,14 +149,14 @@ class Span(object):
             try:
                 self._context.close_span(self)
             except Exception:
-                log.exception('error recording finished trace')
+                log.exception("error recording finished trace")
             else:
                 # if a tracer is available to process the current context
                 if self.tracer:
                     try:
                         self.tracer.record(self._context)
                     except Exception:
-                        log.exception('error recording finished trace')
+                        log.exception("error recording finished trace")
 
     def set_tag(self, key, value=None):
         """ Set the given key / value tag pair on the span. Keys and values
@@ -170,7 +174,7 @@ class Span(object):
 
         # Explicitly try to convert expected integers to `int`
         # DEV: Some integrations parse these values from strings, but don't call `int(value)` themselves
-        INT_TYPES = (net.TARGET_PORT, )
+        INT_TYPES = (net.TARGET_PORT,)
         if key in INT_TYPES and not is_an_int:
             try:
                 value = int(value)
@@ -194,7 +198,7 @@ class Span(object):
                 # DEV: `set_metric` will try to cast to `float()` for us
                 self.set_metric(key, value)
             except (TypeError, ValueError):
-                log.debug('error setting numeric metric %s:%s', key, value)
+                log.debug("error setting numeric metric %s:%s", key, value)
 
             return
 
@@ -217,7 +221,7 @@ class Span(object):
             if key in self.metrics:
                 del self.metrics[key]
         except Exception:
-            log.debug('error setting tag %s, ignoring it', key, exc_info=True)
+            log.debug("error setting tag %s, ignoring it", key, exc_info=True)
 
     def _remove_tag(self, key):
         if key in self.meta:
@@ -251,7 +255,7 @@ class Span(object):
             try:
                 value = int(bool(value))
             except (ValueError, TypeError):
-                log.warning('failed to convert %r tag to an integer from %r', key, value)
+                log.warning("failed to convert %r tag to an integer from %r", key, value)
                 return
 
         # FIXME[matt] we could push this check to serialization time as well.
@@ -262,12 +266,12 @@ class Span(object):
             try:
                 value = float(value)
             except (ValueError, TypeError):
-                log.debug('ignoring not number metric %s:%s', key, value)
+                log.debug("ignoring not number metric %s:%s", key, value)
                 return
 
         # don't allow nan or inf
         if math.isnan(value) or math.isinf(value):
-            log.debug('ignoring not real metric %s:%s', key, value)
+            log.debug("ignoring not real metric %s:%s", key, value)
             return
 
         if key in self.meta:
@@ -288,36 +292,36 @@ class Span(object):
         if self.trace_id.bit_length() > 63:
             trace_id = int(format(self.trace_id, "016x")[-16:], 16)
         d = {
-            'trace_id': trace_id,
-            'parent_id': self.parent_id,
-            'span_id': self.span_id,
-            'service': self.service,
-            'resource': self.resource,
-            'name': self.name,
-            'error': self.error,
+            "trace_id": trace_id,
+            "parent_id": self.parent_id,
+            "span_id": self.span_id,
+            "service": self.service,
+            "resource": self.resource,
+            "name": self.name,
+            "error": self.error,
         }
 
         # a common mistake is to set the error field to a boolean instead of an
         # int. let's special case that here, because it's sure to happen in
         # customer code.
-        err = d.get('error')
+        err = d.get("error")
         if err and type(err) == bool:
-            d['error'] = 1
+            d["error"] = 1
 
         if self.start_ns:
-            d['start'] = self.start_ns
+            d["start"] = self.start_ns
 
         if self.duration_ns:
-            d['duration'] = self.duration_ns
+            d["duration"] = self.duration_ns
 
         if self.meta:
-            d['meta'] = self.meta
+            d["meta"] = self.meta
 
         if self.metrics:
-            d['metrics'] = self.metrics
+            d["metrics"] = self.metrics
 
         if self.span_type:
-            d['type'] = self.span_type
+            d["type"] = self.span_type
 
         return d
 
@@ -327,10 +331,10 @@ class Span(object):
         """
         (exc_type, exc_val, exc_tb) = sys.exc_info()
 
-        if (exc_type and exc_val and exc_tb):
+        if exc_type and exc_val and exc_tb:
             self.set_exc_info(exc_type, exc_val, exc_tb)
         else:
-            tb = ''.join(traceback.format_stack(limit=limit + 1)[:-1])
+            tb = "".join(traceback.format_stack(limit=limit + 1)[:-1])
             self.set_tag(errors.ERROR_STACK, tb)  # FIXME[gabin] Want to replace 'error.stack' tag with 'python.stack'
 
     def set_exc_info(self, exc_type, exc_val, exc_tb):
@@ -346,7 +350,7 @@ class Span(object):
         tb = buff.getvalue()
 
         # readable version of type (e.g. exceptions.ZeroDivisionError)
-        exc_type_str = '%s.%s' % (exc_type.__module__, exc_type.__name__)
+        exc_type_str = "%s.%s" % (exc_type.__module__, exc_type.__name__)
 
         self.set_tag(errors.ERROR_MSG, exc_val)
         self.set_tag(errors.ERROR_TYPE, exc_type_str)
@@ -362,22 +366,22 @@ class Span(object):
     def pprint(self):
         """ Return a human readable version of the span. """
         lines = [
-            ('name', self.name),
-            ('id', self.span_id),
-            ('trace_id', self.trace_id),
-            ('parent_id', self.parent_id),
-            ('service', self.service),
-            ('resource', self.resource),
-            ('type', self.span_type),
-            ('start', self.start),
-            ('end', '' if not self.duration else self.start + self.duration),
-            ('duration', '%fs' % (self.duration or 0)),
-            ('error', self.error),
-            ('tags', '')
+            ("name", self.name),
+            ("id", self.span_id),
+            ("trace_id", self.trace_id),
+            ("parent_id", self.parent_id),
+            ("service", self.service),
+            ("resource", self.resource),
+            ("type", self.span_type),
+            ("start", self.start),
+            ("end", "" if not self.duration else self.start + self.duration),
+            ("duration", "%fs" % (self.duration or 0)),
+            ("error", self.error),
+            ("tags", ""),
         ]
 
-        lines.extend((' ', '%s:%s' % kv) for kv in sorted(self.meta.items()))
-        return '\n'.join('%10s %s' % l for l in lines)
+        lines.extend((" ", "%s:%s" % kv) for kv in sorted(self.meta.items()))
+        return "\n".join("%10s %s" % line for line in lines)
 
     @property
     def context(self):
@@ -397,10 +401,10 @@ class Span(object):
                 self.set_exc_info(exc_type, exc_val, exc_tb)
             self.finish()
         except Exception:
-            log.exception('error closing trace')
+            log.exception("error closing trace")
 
     def __repr__(self):
-        return '<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>' % (
+        return "<Span(id=%s,trace_id=%s,parent_id=%s,name=%s)>" % (
             self.span_id,
             self.trace_id,
             self.parent_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
   | build/
   | dist/
   | ddtrace/(
-    (?!compat\.py$)[^/]+\.py$
+    (?!(compat|span|__init__)\.py$)[^/]+\.py$
     | commands/
     | contrib/
     (

--- a/tests/contrib/asyncio/test_tracer.py
+++ b/tests/contrib/asyncio/test_tracer.py
@@ -370,6 +370,7 @@ class TestAsyncioPropagation(AsyncioTestCase):
         # if multiple coroutines have nested tracing, they must belong
         # to the same trace
         ot_tracer = init_tracer('asyncio_svc', self.tracer)
+
         @asyncio.coroutine
         def coro():
             # another traced coroutine

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,11 @@ envlist =
     {py27,py34,py35,py36,py37,py38}-test_utils
     {py27,py34,py35,py36,py37,py38}-test_logging
 # Integrations environments
-    aiobotocore_contrib-py34-aiobotocore{02,03,04}
-    aiobotocore_contrib-{py35,py36}-aiobotocore{02,03,04,05,07,08,09,010,011,latest}
+    # aiobotocore dropped Python 3.5 support in 0.12
+    aiobotocore_contrib-{py35}-aiobotocore{02,03,04,05,07,08,09,010,011}
+    aiobotocore_contrib-{py36}-aiobotocore{02,03,04,05,07,08,09,010,011,012}
     # aiobotocore 0.2 and 0.4 do not work because they use async as a reserved keyword
-    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,latest}
+    aiobotocore_contrib-py{37,38}-aiobotocore{03,05,07,08,09,010,011,012}
     # Python 3.7 needs at least aiohttp 2.3
     aiohttp_contrib-{py34,py35,py36}-aiohttp{12,13,20,21,22}-aiohttp_jinja{012,013}-yarl
     aiohttp_contrib-{py34,py35,py36,py37,py38}-aiohttp23-aiohttp_jinja015-yarl10
@@ -195,7 +196,8 @@ deps =
 # backports
     py27: enum34
 # integrations
-    aiobotocorelatest: aiobotocore>=0.11
+    # aiobotocore: aiobotocore>=1.0 not yet supported
+    aiobotocore012: aiobotocore>=0.12,<0.13
     aiobotocore011: aiobotocore>=0.11,<0.12
     aiobotocore010: aiobotocore>=0.10,<0.11
     aiobotocore09: aiobotocore>=0.9,<0.10

--- a/tox.ini
+++ b/tox.ini
@@ -537,7 +537,7 @@ commands=black --check .
 commands_pre=
 skip_install=true
 deps=
-  flake8>=3.7,<=3.8
+  flake8>=3.8,<=3.9
   flake8-blind-except
   flake8-builtins
   flake8-docstrings


### PR DESCRIPTION
When a service instrumented with ls-trace extracts a trace ID from a b3 header, if that ID is a 128 bit ID, the msgpack encoding fails. This change trims the ID if it is longer than 64 bits.